### PR TITLE
Expose replaceCodes

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -22,6 +22,8 @@ h2. Usage
   print(colors('%{bright red underlined}hello'))
 </pre>
 
+The @colors@ function makes sure that color attributes are reset at each end of the generated string. If you want to generate complex strings piece-by-piece, use @colors.replaceCodes@, which works exactly the same, but without adding the reset codes at each end of the string.
+
 h2. Testing
 
 This application uses telescope in order to perform the tests. Install telescope, and then execute

--- a/ansicolors.lua
+++ b/ansicolors.lua
@@ -97,4 +97,4 @@ local function ansicolors( str )
 end
 
 
-return setmetatable({replaceCodes = replaceCodes}, {__call = ansicolors})
+return setmetatable({noReset = replaceCodes}, {__call = ansicolors})

--- a/ansicolors.lua
+++ b/ansicolors.lua
@@ -97,4 +97,4 @@ local function ansicolors( str )
 end
 
 
-return setmetatable({noReset = replaceCodes}, {__call = ansicolors})
+return setmetatable({noReset = replaceCodes}, {__call = function (_, str) return ansicolors (str) end})

--- a/ansicolors.lua
+++ b/ansicolors.lua
@@ -97,4 +97,4 @@ local function ansicolors( str )
 end
 
 
-return ansicolors
+return setmetatable({replaceCodes = replaceCodes}, {__call = ansicolors})

--- a/specs/ansicolors_spec.lua
+++ b/specs/ansicolors_spec.lua
@@ -38,11 +38,11 @@ describe('ansicolors', function()
     end)
 
     it('should add red underlined text', function()
-      assert_equal(ansicolors('%{red underline}foo'), c27 .. '[31m' .. c27 .. '[4mfoo')
+      assert_equal(ansicolors.noReset('%{red underline}foo'), c27 .. '[31m' .. c27 .. '[4mfoo')
     end)
 
     it('should with heterogeneous attributes', function()
-      assert_equal(ansicolors('%{bright white}*%{bright red}BEEP%{bright white}*'),  c27 .. '[1m' .. c27 .. '[37m*' .. c27 .. '[1m' .. c27 .. '[31mBEEP' .. c27 .. '[1m' .. c27 .. '[37m*')
+      assert_equal(ansicolors.noReset('%{bright white}*%{bright red}BEEP%{bright white}*'),  c27 .. '[1m' .. c27 .. '[37m*' .. c27 .. '[1m' .. c27 .. '[31mBEEP' .. c27 .. '[1m' .. c27 .. '[37m*')
     end)
 
   end)

--- a/specs/ansicolors_spec.lua
+++ b/specs/ansicolors_spec.lua
@@ -24,6 +24,29 @@ describe('ansicolors', function()
     assert_equal(ansicolors('%{bright white}*%{bright red}BEEP%{bright white}*'),  c27 .. '[0m' .. c27 .. '[1m' .. c27 .. '[37m*' .. c27 .. '[1m' .. c27 .. '[31mBEEP' .. c27 .. '[1m' .. c27 .. '[37m*' .. c27 .. '[0m')
   end)
 
+  describe('noReset', function ()
+    it('should do nothing if no options given', function()
+      assert_equal(ansicolors.noReset('foo'), 'foo' )
+    end)
+
+    it('should throw an error on invalid options', function()
+      assert_error(function() ansicolors.noReset('%{blah}foo') end)
+    end)
+
+    it('should add red color to text', function()
+      assert_equal(ansicolors.noReset('%{red}foo'), c27 .. '[31mfoo')
+    end)
+
+    it('should add red underlined text', function()
+      assert_equal(ansicolors('%{red underline}foo'), c27 .. '[31m' .. c27 .. '[4mfoo')
+    end)
+
+    it('should with heterogeneous attributes', function()
+      assert_equal(ansicolors('%{bright white}*%{bright red}BEEP%{bright white}*'),  c27 .. '[1m' .. c27 .. '[37m*' .. c27 .. '[1m' .. c27 .. '[31mBEEP' .. c27 .. '[1m' .. c27 .. '[37m*')
+    end)
+
+  end)
+
   describe('support detection', function()
 
     it('should return a plain text string on systems with no package.config', function()


### PR DESCRIPTION
For some uses, it's annoying that the colors function adds reset codes at each end of the generated string, so expose replaceCodes. This is done in a backwards-compatible way, and explained in the updated README.
