### PR TITLE
Fix warning during luarocks installation

### DIFF
--- a/ansicolors-1.0.2-2.rockspec
+++ b/ansicolors-1.0.2-2.rockspec
@@ -1,5 +1,5 @@
 package = "ansicolors"
-version = "1.0.2-1"
+version = "1.0.2-2"
 source = {
   url = "https://github.com/kikito/ansicolors.lua/archive/v1.0.2.tar.gz",
   dir = "ansicolors.lua-1.0.2"
@@ -19,5 +19,6 @@ build = {
   type = "builtin",
   modules = {
     ["ansicolors"] = "ansicolors.lua"
-  }
+  },
+  copy_directories = {}
 }


### PR DESCRIPTION
This commit just adds a line to the rockspec so that luarocks doesn't warn about the lack of "doc" directory.
