### PR TITLE
Add `ansicolor.<color>` methods for fast colorizing

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -22,6 +22,15 @@ h2. Usage
   print(colors('%{bright red underline}hello'))
 </pre>
 
+or
+
+<pre>
+  local colors = require 'ansicolors'
+  print(colors.red('hello'))
+  print(colors.redbg('hello'))
+  print(colors.bright_red_underline('hello'))
+</pre>
+
 The @colors@ function makes sure that color attributes are reset at each end of the generated string. If you want to generate complex strings piece-by-piece, use @colors.noReset@, which works exactly the same, but without adding the reset codes at each end of the string.
 
 h2. Testing

--- a/ansicolors.lua
+++ b/ansicolors.lua
@@ -97,4 +97,13 @@ local function ansicolors( str )
 end
 
 
-return setmetatable({noReset = replaceCodes}, {__call = function (_, str) return ansicolors (str) end})
+return setmetatable({noReset = replaceCodes}, {
+  __call = function (_, str) return ansicolors (str) end,
+  __index = function (_, name)
+    return function(input)
+      return ansicolors("%{"..name.."}"..input)
+    end
+  end
+})
+
+

--- a/ansicolors.lua
+++ b/ansicolors.lua
@@ -100,11 +100,12 @@ end
 return setmetatable({noReset = replaceCodes}, {
   __call = function (_, str) return ansicolors (str) end,
   __index = function (self, name)
-    return function(input)
-      local fn = ansicolors("%{"..name.."}"..input)
-      self[name] = fn
-      return fn
+    local prefix = "%{"..name.."}"
+    local fn = function(input)
+      return ansicolors(prefix..input)
     end
+    self[name] = fn
+    return fn
   end
 })
 

--- a/ansicolors.lua
+++ b/ansicolors.lua
@@ -99,9 +99,11 @@ end
 
 return setmetatable({noReset = replaceCodes}, {
   __call = function (_, str) return ansicolors (str) end,
-  __index = function (_, name)
+  __index = function (self, name)
     return function(input)
-      return ansicolors("%{"..name.."}"..input)
+      local fn = ansicolors("%{"..name.."}"..input)
+      self[name] = fn
+      return fn
     end
   end
 })

--- a/specs/ansicolors_spec.lua
+++ b/specs/ansicolors_spec.lua
@@ -44,6 +44,22 @@ describe('ansicolors', function()
     it('should with heterogeneous attributes', function()
       assert_equal(ansicolors.noReset('%{bright white}*%{bright red}BEEP%{bright white}*'),  c27 .. '[1m' .. c27 .. '[37m*' .. c27 .. '[1m' .. c27 .. '[31mBEEP' .. c27 .. '[1m' .. c27 .. '[37m*')
     end)
+        
+    describe('<color> shorthands', function()
+      it('should work just like the string interpolation syntax', function()
+        assert_equal(
+          ansicolors('%{red blink}test'),
+          ansicolors.red_blink('test')
+        )
+      end)
+
+      it('should be memoized', function()
+        assert_equal(
+          ansicolors.red,
+          ansicolors.red
+        )
+      end)
+    end)
 
   end)
 


### PR DESCRIPTION
This allows writing

```lua
ansicolors.red_blink(message)
```

instead of

```lua
ansicolors("%{red blink}"..message)
```

which looks quite a bit easier to visually parse.